### PR TITLE
removed multiplier from trail radius scale

### DIFF
--- a/osr2mp4/ImageProcess/Objects/Components/Cursor.py
+++ b/osr2mp4/ImageProcess/Objects/Components/Cursor.py
@@ -32,7 +32,7 @@ class Cursortrail(FrameObject):
 	def __init__(self, trail_frames, continuous, settings):
 		super().__init__(trail_frames, settings=settings)
 		self.continuous = continuous
-		self.radius = self.settings.scale * 3
+		self.radius = self.settings.scale
 		self.alphas = []  # for continuous trail
 		self.updatetime = 1000/60
 		self.updatecooldown = 0


### PR DESCRIPTION
removed multiplier ( * 3) from `self.radius = self.settings.scale * 3` to give a smoother long trail