### PR TITLE
Use a package-specific logger

### DIFF
--- a/osr2mp4/AudioProcess/CreateAudio.py
+++ b/osr2mp4/AudioProcess/CreateAudio.py
@@ -70,7 +70,7 @@ def pydubtonumpy(audiosegment):
 		h = max(2, audiosegment.sample_width) * 8
 		maxvalue = max(np.amax(y), 2 ** h)
 	except ValueError as e:
-		print(repr(e))
+		logger.error(repr(e))
 		maxvalue = 1
 	return audiosegment.frame_rate, np.float64(y) / maxvalue
 
@@ -85,15 +85,13 @@ def getaudiofromfile(filename, path, defaultpath, settings, volume=1.0, speed=1.
 
 		except exceptions.CouldntDecodeError as e:
 			logger.error(repr(e) + " filename " + os.path.join(path, filename + "." + fmt))
-			print(repr(e) + " filename " + os.path.join(path, filename + "." + fmt))
 			return 1, np.zeros((0, 2), dtype=np.float32)
 
-	print("file not found",  filename, "using default skin")
+	logger.warning("file not found",  filename, "using default skin")
 
 	if defaultpath is not None:
 		return getaudiofromfile(filename, defaultpath, None, settings, volume=volume, speed=speed)
 
-	print("file not found" + filename)
 	logger.error("file not found " + filename)
 	return 1, np.zeros((0, 2), dtype=np.float32)
 
@@ -198,7 +196,7 @@ def audioprc(my_info, beatmap, offset, endtime, mods, settings):
 
 	hitsoundm = HitsoundManager(beatmap)
 
-	print("Done loading", time.time() - ccc)
+	logger.debug("Done loading", time.time() - ccc)
 
 	for x in range(len(my_info)):
 

--- a/osr2mp4/AudioProcess/CreateAudio.py
+++ b/osr2mp4/AudioProcess/CreateAudio.py
@@ -87,12 +87,12 @@ def getaudiofromfile(filename, path, defaultpath, settings, volume=1.0, speed=1.
 			logger.error(repr(e) + " filename " + os.path.join(path, filename + "." + fmt))
 			return 1, np.zeros((0, 2), dtype=np.float32)
 
-	logger.warning("file not found",  filename, "using default skin")
+	logger.warning("file not found %s, using default skin",  filename)
 
 	if defaultpath is not None:
 		return getaudiofromfile(filename, defaultpath, None, settings, volume=volume, speed=speed)
 
-	logger.error("file not found " + filename)
+	logger.error("file not found %s", filename)
 	return 1, np.zeros((0, 2), dtype=np.float32)
 
 
@@ -196,7 +196,7 @@ def audioprc(my_info, beatmap, offset, endtime, mods, settings):
 
 	hitsoundm = HitsoundManager(beatmap)
 
-	logger.debug("Done loading", time.time() - ccc)
+	logger.debug("Done loading: %f", time.time() - ccc)
 
 	for x in range(len(my_info)):
 

--- a/osr2mp4/AudioProcess/CreateAudio.py
+++ b/osr2mp4/AudioProcess/CreateAudio.py
@@ -1,4 +1,3 @@
-import logging
 import math
 import os
 import subprocess
@@ -12,6 +11,7 @@ from scipy.io.wavfile import write
 import numpy as np
 from pydub import AudioSegment
 from pydub import exceptions
+from osr2mp4 import logger
 from osr2mp4.AudioProcess.AddAudio import HitsoundManager
 from osr2mp4.AudioProcess.Hitsound import Hitsound
 from osr2mp4.AudioProcess.Utils import getfilenames
@@ -84,7 +84,7 @@ def getaudiofromfile(filename, path, defaultpath, settings, volume=1.0, speed=1.
 			pass
 
 		except exceptions.CouldntDecodeError as e:
-			logging.error(repr(e) + " filename " + os.path.join(path, filename + "." + fmt))
+			logger.error(repr(e) + " filename " + os.path.join(path, filename + "." + fmt))
 			print(repr(e) + " filename " + os.path.join(path, filename + "." + fmt))
 			return 1, np.zeros((0, 2), dtype=np.float32)
 
@@ -94,7 +94,7 @@ def getaudiofromfile(filename, path, defaultpath, settings, volume=1.0, speed=1.
 		return getaudiofromfile(filename, defaultpath, None, settings, volume=volume, speed=speed)
 
 	print("file not found" + filename)
-	logging.error("file not found " + filename)
+	logger.error("file not found " + filename)
 	return 1, np.zeros((0, 2), dtype=np.float32)
 
 
@@ -168,7 +168,7 @@ def processaudio(my_info, beatmap, offset, endtime, mods, settings):
 		error = repr(e)
 		with open("error.txt", "w") as fwrite:  # temporary fix
 			fwrite.write(repr(e))
-		logging.error("{} from audio\n\n\n".format(error))
+		logger.error("{} from audio\n\n\n".format(error))
 		raise
 
 

--- a/osr2mp4/CheckSystem/checkmain.py
+++ b/osr2mp4/CheckSystem/checkmain.py
@@ -1,5 +1,4 @@
-import logging
-
+from osr2mp4 import logger
 from osr2mp4.osrparse.enums import Mod
 
 from osr2mp4.CheckSystem.HitObjectChecker import HitObjectChecker
@@ -60,7 +59,7 @@ def checkmain(beatmap, replay_info, settings, tests=False):
 	breakperiod = beatmap.breakperiods[break_index]
 	in_break = int(replay_event[osr_index][Replays.TIMES]) in range(breakperiod["Start"], breakperiod["End"])
 
-	logging.debug("Start check")
+	logger.debug("Start check")
 	while osr_index < len(replay_event) - 3:
 		k1, k2, m1, m2 = keys(replay_event[osr_index][Replays.KEYS_PRESSED])
 		if not in_break:
@@ -83,6 +82,6 @@ def checkmain(beatmap, replay_info, settings, tests=False):
 			breakperiod = beatmap.breakperiods[break_index]
 		in_break = int(replay_event[osr_index][Replays.TIMES]) in range(breakperiod["Start"], breakperiod["End"])
 
-	logging.debug("check done")
-	logging.log(1, "RETURN %r", hitobjectchecker.info[-1])
+	logger.debug("check done")
+	logger.log(1, "RETURN %r", hitobjectchecker.info[-1])
 	return hitobjectchecker.info

--- a/osr2mp4/ImageProcess/Objects/Components/AScorebar.py
+++ b/osr2mp4/ImageProcess/Objects/Components/AScorebar.py
@@ -48,4 +48,3 @@ class AScorebar(FrameObject):
 		if not self.scrolling and self.interval == 0:
 			self.alpha = 1
 			self.h = 0
-

--- a/osr2mp4/ImageProcess/Objects/Components/Scoreboard.py
+++ b/osr2mp4/ImageProcess/Objects/Components/Scoreboard.py
@@ -1,11 +1,11 @@
 import json
-import logging
 import os
 
 import requests
 from osr2mp4.ImageProcess.Animation.easing import easingoutquad
 from recordclass import recordclass
 import re
+from osr2mp4 import logger
 from osr2mp4.ImageProcess import imageproc
 from osr2mp4.ImageProcess.Objects.FrameObject import FrameObject
 from osr2mp4.ImageProcess.PrepareFrames.Components.Text import prepare_text
@@ -242,7 +242,7 @@ class Scoreboard(FrameObject):
 		try:
 			scores = getscores(self.beatmaphash, os.path.join(self.settings.osu, "scores.db"))
 		except Exception as e:
-			logging.error("from scoreboard", repr(e))
+			logger.error("from scoreboard", repr(e))
 			return
 
 		for i in range(len(scores["scores"])):
@@ -441,4 +441,3 @@ class Scoreboard(FrameObject):
 		except ValueError:
 			self.scoresid.append(userid)
 			return True
-

--- a/osr2mp4/ImageProcess/Objects/Components/Scoreboard.py
+++ b/osr2mp4/ImageProcess/Objects/Components/Scoreboard.py
@@ -145,7 +145,7 @@ class Scoreboard(FrameObject):
 
 		k = self.settings.settings["api key"]
 		if k is None:
-			print("\n\n YOU DID NOT ENTERED THE API KEY. GET THE API HERE https://osu.ppy.sh/p/api/\n\n")
+			logger.error("\n\n YOU DID NOT ENTERED THE API KEY. GET THE API HERE https://osu.ppy.sh/p/api/\n\n")
 			return
 
 		data = {'k': k, 'h': maphash}
@@ -196,7 +196,7 @@ class Scoreboard(FrameObject):
 	def getglobalscores(self, mods):
 		k = self.settings.settings["api key"]
 		if k is None:
-			print("\n\n YOU DID NOT ENTERED THE API KEY. GET THE API HERE https://osu.ppy.sh/p/api/\n\n")
+			logger.error("\n\n YOU DID NOT ENTERED THE API KEY. GET THE API HERE https://osu.ppy.sh/p/api/\n\n")
 			self.getlocalscores(mods)
 			return
 
@@ -213,7 +213,7 @@ class Scoreboard(FrameObject):
 			return
 
 		if "error" in data:
-			print("\n\n {} \n\n".format(data["error"]))
+			logger.error("\n\n {} \n\n".format(data["error"]))
 			self.getlocalscores(mods)
 			return
 

--- a/osr2mp4/ImageProcess/Objects/Components/Scoreboard.py
+++ b/osr2mp4/ImageProcess/Objects/Components/Scoreboard.py
@@ -242,7 +242,7 @@ class Scoreboard(FrameObject):
 		try:
 			scores = getscores(self.beatmaphash, os.path.join(self.settings.osu, "scores.db"))
 		except Exception as e:
-			logger.error("from scoreboard", repr(e))
+			logger.error("from scoreboard: %s", repr(e))
 			return
 
 		for i in range(len(scores["scores"])):

--- a/osr2mp4/ImageProcess/Objects/HitObjects/CircleNumber.py
+++ b/osr2mp4/ImageProcess/Objects/HitObjects/CircleNumber.py
@@ -8,7 +8,7 @@ class Number(FrameObject):
 		self.nwidth = self.w()
 		scale = frames[1]
 		self.overlap = int(fonts["HitCircleOverlap"]*scale)
-		logger.debug(self.overlap, fonts["HitCircleOverlap"], scale)
+		logger.debug("%s %s %s", self.overlap, fonts["HitCircleOverlap"], scale)
 
 	def add_to_frame(self, background, x, y, alpha, number):
 		"""

--- a/osr2mp4/ImageProcess/Objects/HitObjects/CircleNumber.py
+++ b/osr2mp4/ImageProcess/Objects/HitObjects/CircleNumber.py
@@ -1,3 +1,4 @@
+from osr2mp4 import logger
 from osr2mp4.ImageProcess.Objects.FrameObject import FrameObject
 
 
@@ -7,7 +8,7 @@ class Number(FrameObject):
 		self.nwidth = self.w()
 		scale = frames[1]
 		self.overlap = int(fonts["HitCircleOverlap"]*scale)
-		print(self.overlap, fonts["HitCircleOverlap"], scale)
+		logger.debug(self.overlap, fonts["HitCircleOverlap"], scale)
 
 	def add_to_frame(self, background, x, y, alpha, number):
 		"""

--- a/osr2mp4/ImageProcess/Objects/Scores/ACounter.py
+++ b/osr2mp4/ImageProcess/Objects/Scores/ACounter.py
@@ -1,7 +1,6 @@
-import logging
-
 from PIL import Image
 
+from osr2mp4 import logger
 from osr2mp4.ImageProcess import imageproc
 from osr2mp4.ImageProcess.PrepareFrames.Components.Text import prepare_text
 
@@ -39,7 +38,7 @@ class ACounter:
 			scale = self.settings.scale * self.countersettings[self.prefix + "Size"]/20
 			self.background = imageproc.change_size(self.background, scale, scale)
 		except Exception as e:
-			logging.error(repr(e))
+			logger.error(repr(e))
 			self.background = Image.new("RGBA", (1, 1))
 
 	def update(self, score):

--- a/osr2mp4/ImageProcess/Objects/Scores/ScoreNumbers.py
+++ b/osr2mp4/ImageProcess/Objects/Scores/ScoreNumbers.py
@@ -1,4 +1,5 @@
 from PIL import Image
+from osr2mp4 import logger
 from osr2mp4.ImageProcess.PrepareFrames.YImage import YImage
 
 
@@ -13,7 +14,7 @@ class ScoreNumbers:
 			self.score_images.append(YImage(scoreprefix + str(x), settings, scale, prefix="ScorePrefix"))
 
 		self.score_percent = YImage(score_percent, settings, scale, prefix="ScorePrefix")
-		print(scale)
+		logger.debug(scale)
 		# fierymod_v8_realest_ver[1] has very big score_percent.png but it doesn't show up in real osu
 		# after some testing, if the image is >= 570px then it won't show up
 		if self.score_percent.orig_cols >= int(570 * scale):

--- a/osr2mp4/ImageProcess/PrepareFrames/Components/Background.py
+++ b/osr2mp4/ImageProcess/PrepareFrames/Components/Background.py
@@ -1,9 +1,9 @@
-import logging
 import os
 
 import numpy as np
 from PIL import Image
 
+from osr2mp4 import logger
 from osr2mp4.ImageProcess import imageproc
 
 
@@ -15,7 +15,7 @@ def prepare_background(backgroundname, settings):
 	try:
 		img = Image.open(backgroundname).convert("RGBA")
 	except Exception as e:
-		logging.error(repr(e))
+		logger.error(repr(e))
 		img = Image.open(os.path.join(settings.path, "res/bg.png")).convert("RGBA")
 
 	width = settings.width

--- a/osr2mp4/ImageProcess/PrepareFrames/Components/Text.py
+++ b/osr2mp4/ImageProcess/PrepareFrames/Components/Text.py
@@ -1,6 +1,5 @@
-import logging
-
 from PIL import ImageFont, ImageDraw, Image
+from osr2mp4 import logger
 from osr2mp4.ImageProcess import imageproc
 import os
 
@@ -13,7 +12,7 @@ def prepare_text(texts, size, color, settings, alpha=1, fontpath=""):
 		font = ImageFont.truetype(fontpath, size=size)
 	except Exception as e:
 		font = ImageFont.truetype(os.path.join(settings.path, "res/Aller_Rg.ttf"), size=size)
-		logging.error(repr(e))
+		logger.error(repr(e))
 
 	img = Image.new("RGBA", (settings.width, settings.height))
 	imgdraw = ImageDraw.Draw(img)
@@ -25,4 +24,3 @@ def prepare_text(texts, size, color, settings, alpha=1, fontpath=""):
 		imgs[text] = imageproc.newalpha(img.crop((0, 0, s[0], s[1])), alpha)
 
 	return imgs
-

--- a/osr2mp4/ImageProcess/PrepareFrames/HitObjects/Circles.py
+++ b/osr2mp4/ImageProcess/PrepareFrames/HitObjects/Circles.py
@@ -2,6 +2,7 @@
 # Circle
 from PIL import Image
 
+from osr2mp4 import logger
 from osr2mp4.EEnum.EImageFrom import ImageFrom
 from osr2mp4.ImageProcess import imageproc
 from osr2mp4.ImageProcess.Animation import alpha, size
@@ -188,6 +189,6 @@ def prepare_circle(diff, scale, settings, hd):
 				alphas.append(alpha)
 				alpha = max(0, min(100, alpha + ii))
 
-	print("done")
+	logger.debug("done")
 
 	return slidercircle_frames, circle_frames, fadeout, alphas

--- a/osr2mp4/ImageProcess/PrepareFrames/YImage.py
+++ b/osr2mp4/ImageProcess/PrepareFrames/YImage.py
@@ -3,6 +3,7 @@ import os
 import cv2
 import numpy as np
 from PIL import Image, UnidentifiedImageError
+from osr2mp4 import logger
 from osr2mp4.EEnum.EImageFrom import ImageFrom
 from osr2mp4.ImageProcess import imageproc
 
@@ -41,7 +42,7 @@ class YImage:
 			scaley = scale
 
 		if self.x2:
-			# print(self.filename)
+			# logger.debug(self.filename)
 			scale /= 2
 			scaley /= 2
 
@@ -54,7 +55,7 @@ class YImage:
 			self.orig_rows = self.img.size[1]
 			self.orig_cols = self.img.size[0]
 
-		# print(filename)
+		# logger.debug(filename)
 
 	def loadx2(self, path, pre, filename=None):
 		if filename is None:
@@ -141,7 +142,7 @@ class YImages:
 
 		self.load(defaultpath=False)
 		if self.unanimate and self.imgfrom == ImageFrom.BLANK:
-			print("Loading default path YImagesss", filename)
+			logger.debug("Loading default path YImagesss", filename)
 			self.frames = []
 			self.load(defaultpath=True)
 
@@ -165,4 +166,3 @@ class YImages:
 			self.frames.append(a.img)
 
 		self.n_frame = len(self.frames)
-

--- a/osr2mp4/ImageProcess/PrepareFrames/YImage.py
+++ b/osr2mp4/ImageProcess/PrepareFrames/YImage.py
@@ -142,7 +142,7 @@ class YImages:
 
 		self.load(defaultpath=False)
 		if self.unanimate and self.imgfrom == ImageFrom.BLANK:
-			logger.debug("Loading default path YImagesss", filename)
+			logger.debug("Loading default path YImagesss: %s", filename)
 			self.frames = []
 			self.load(defaultpath=True)
 

--- a/osr2mp4/Parser/osuparser.py
+++ b/osr2mp4/Parser/osuparser.py
@@ -308,7 +308,7 @@ class Beatmap:
 				else:
 					my_dict["velocity"] = sliderscoringdistance * self.diff["SliderTickRate"]
 
-				# logger.debug(my_dict["velocity"], my_dict["pixel length"] / (my_dict["end time"] - my_dict["time"]) * 1000)
+				# logger.debug("%s %s", my_dict["velocity"], my_dict["pixel length"] / (my_dict["end time"] - my_dict["time"]) * 1000)
 
 				my_dict["hitSound"] = osuobject[4]
 				if len(osuobject) > 9:

--- a/osr2mp4/Parser/osuparser.py
+++ b/osr2mp4/Parser/osuparser.py
@@ -308,7 +308,7 @@ class Beatmap:
 				else:
 					my_dict["velocity"] = sliderscoringdistance * self.diff["SliderTickRate"]
 
-				# print(my_dict["velocity"], my_dict["pixel length"] / (my_dict["end time"] - my_dict["time"]) * 1000)
+				# logger.debug(my_dict["velocity"], my_dict["pixel length"] / (my_dict["end time"] - my_dict["time"]) * 1000)
 
 				my_dict["hitSound"] = osuobject[4]
 				if len(osuobject) > 9:
@@ -513,7 +513,7 @@ def split(delimiters, string):
 
 def read_file(filename, scale=1, colors=None, hr=False, dt=False, mods=None, lazy=True):
 	if hr or dt:
-		print("hr args is depecrated")
+		logger.warning("hr args is depecrated")
 
 	fiel = open(filename, "r", encoding="utf-8")
 	content = fiel.read()

--- a/osr2mp4/Parser/osuparser.py
+++ b/osr2mp4/Parser/osuparser.py
@@ -1,6 +1,6 @@
-import logging
 import math
 
+from osr2mp4 import logger
 from osr2mp4.Utils.maphash import osuhash
 from osr2mp4.Exceptions import GameModeNotSupported
 
@@ -138,7 +138,7 @@ class Beatmap:
 				my_dict["SampleIndex"] = my_dict.get("SampleIndex", "0")
 				my_dict["Volume"] = my_dict.get("Volume", 100)
 				self.timing_point.append(my_dict)
-				logging.error(repr(e))
+				logger.error(repr(e))
 				continue
 			# my_dict["Kiai"] = int(items[7])
 			self.timing_point.append(my_dict)

--- a/osr2mp4/Parser/scoresparser.py
+++ b/osr2mp4/Parser/scoresparser.py
@@ -1,4 +1,5 @@
 from struct import unpack_from
+from osr2mp4 import logger
 
 
 def parseNum(db, offset, length):
@@ -52,7 +53,7 @@ def parseString(db, offset):
 		try:
 			unic = str(string, 'utf-8')
 		except UnicodeDecodeError:
-			print("Could not parse UTF-8 string, returning empty string.")
+			logger.error("Could not parse UTF-8 string, returning empty string.")
 
 		return (unic, offset)
 

--- a/osr2mp4/Parser/skinparser.py
+++ b/osr2mp4/Parser/skinparser.py
@@ -98,9 +98,9 @@ class Skin:
 		self.parse_colors()
 		self.parse_fonts()
 
-		# print(self.general)
-		# print(self.colours)
-		# print(self.fonts)
+		# logger.debug(self.general)
+		# logger.debug(self.colours)
+		# logger.debug(self.fonts)
 
 	def filter(self, string):
 		start = "["

--- a/osr2mp4/Parser/skinparser.py
+++ b/osr2mp4/Parser/skinparser.py
@@ -2,10 +2,11 @@
 
 
 # return pos of the first char of the  comment or -1 if there is no comment
-import logging
 import os
 from collections import OrderedDict
 from configparser import ConfigParser
+
+from osr2mp4 import logger
 
 
 def detect_comments(line):
@@ -133,9 +134,9 @@ class Skin:
 		self.colours = getsection(config, "Colours")
 		self.fonts = getsection(config, "Fonts")
 
-		logging.log(1, self.general)
-		logging.log(1, self.colours)
-		logging.log(1, self.fonts)
+		logger.log(1, self.general)
+		logger.log(1, self.colours)
+		logger.log(1, self.fonts)
 
 	def parse_general(self):
 		self.general['CursorRotate'] = iint(self.general.get('CursorRotate', 0))

--- a/osr2mp4/Utils/Setup.py
+++ b/osr2mp4/Utils/Setup.py
@@ -1,8 +1,8 @@
-import logging
 import os
 
 from autologging import traced, logged
 
+from osr2mp4 import logger
 from osr2mp4.global_var import defaultsettings
 from osr2mp4.osrparse.enums import Mod
 
@@ -10,7 +10,7 @@ from osr2mp4.Parser.skinparser import Skin
 from osr2mp4.Utils.Resolution import get_screensize
 
 
-@logged(logging.getLogger(__name__))
+@logged(logger)
 @traced
 def setupglobals(data, gameplaydata, mod_combination, settings, ppsettings=None):
 	skin_path = data["Skin path"]
@@ -75,5 +75,3 @@ def setupglobals(data, gameplaydata, mod_combination, settings, ppsettings=None)
 
 	if ppsettings is not None:
 		settings.ppsettings = ppsettings
-
-

--- a/osr2mp4/Utils/Setup.py
+++ b/osr2mp4/Utils/Setup.py
@@ -38,7 +38,7 @@ def setupglobals(data, gameplaydata, mod_combination, settings, ppsettings=None)
 		time_frame *= 1.5
 	if Mod.HalfTime in mod_combination:
 		time_frame *= 0.75
-	print(time_frame)
+	logger.debug(time_frame)
 
 	playfield_scale, playfield_width, playfield_height, scale, move_right, move_down = get_screensize(width, height)
 	settings.width, settings.height, settings.scale = width, height, scale

--- a/osr2mp4/Utils/Timing.py
+++ b/osr2mp4/Utils/Timing.py
@@ -1,3 +1,4 @@
+from osr2mp4 import logger
 from osr2mp4.VideoProcess.calc import nearer
 from osr2mp4.CheckSystem.Judgement import DiffCalculator
 from osr2mp4.EEnum.EReplay import Replays
@@ -30,7 +31,7 @@ def get_offset(beatmap, start_index, end_index, replay_info, endtime, fps=60):
 
 	offset = replay_event[osr_index][Replays.TIMES]
 	endtime += replay_event[end_index][Replays.TIMES] + 100
-	print("\n\nOFFSET:", offset)
+	logger.debug("\n\nOFFSET:", offset)
 	return offset, endtime
 
 

--- a/osr2mp4/Utils/Timing.py
+++ b/osr2mp4/Utils/Timing.py
@@ -31,7 +31,7 @@ def get_offset(beatmap, start_index, end_index, replay_info, endtime, fps=60):
 
 	offset = replay_event[osr_index][Replays.TIMES]
 	endtime += replay_event[end_index][Replays.TIMES] + 100
-	logger.debug("\n\nOFFSET:", offset)
+	logger.debug("\n\nOFFSET: %s", offset)
 	return offset, endtime
 
 

--- a/osr2mp4/Utils/skip.py
+++ b/osr2mp4/Utils/skip.py
@@ -64,7 +64,7 @@ def search_osrindex(to_time, replays):
 	while cur_index <= len(replays)-1 and replays[cur_index+1][3] < to_time:
 		cur_index += 1
 
-	logger.debug("cur_index", cur_index)
+	logger.debug("cur_index %d", cur_index)
 	return cur_index
 
 

--- a/osr2mp4/Utils/skip.py
+++ b/osr2mp4/Utils/skip.py
@@ -1,3 +1,6 @@
+from osr2mp4 import logger
+
+
 def search_time(to_time, hitobjects):
 	cur_index = 0
 	while cur_index <= len(hitobjects)-2 and hitobjects[cur_index]["end time"] + 1000 < to_time:
@@ -41,7 +44,7 @@ def search_updateindex(idd, resultinfo, component, to_time):
 				component.urbar.movearrow()
 		urindex += 1
 
-	print("done")
+	logger.debug("done")
 	return cur_index
 
 
@@ -61,7 +64,7 @@ def search_osrindex(to_time, replays):
 	while cur_index <= len(replays)-1 and replays[cur_index+1][3] < to_time:
 		cur_index += 1
 
-	print("cur_index", cur_index)
+	logger.debug("cur_index", cur_index)
 	return cur_index
 
 
@@ -104,5 +107,3 @@ def skip(to_time, resultinfo, replayinfo, beatmap, timepreempt, component):
 	fp_index, obj_endtime, x_end, y_end = search_fpindex(starttime, beatmap.hitobjects)
 	break_index = search_break(starttime, beatmap.breakperiods)
 	return starttime, hitobjectindex, info_index, osr_index, fp_index, obj_endtime, x_end, y_end, break_index
-
-

--- a/osr2mp4/VideoProcess/AFrames.py
+++ b/osr2mp4/VideoProcess/AFrames.py
@@ -1,6 +1,6 @@
-import logging
 import os
 
+from osr2mp4 import logger
 from osr2mp4.ImageProcess.PrepareFrames.Scores.URArrow import prepare_urarrow
 from osr2mp4.ImageProcess.Objects.Components.Flashlight import Flashlight
 from osr2mp4.ImageProcess.PrepareFrames.Components.Flashlight import prepare_flashlight
@@ -95,24 +95,24 @@ class PreparedFrames:
 		if bg is None:
 			bg = [0, 0, ""]
 
-		logging.debug('start preparing cursor')
+		logger.debug('start preparing cursor')
 		self.cursor, default = prepare_cursor(settings.scale * settings.settings["Cursor size"], settings)
-		logging.debug('start preparing cursormiddle')
+		logger.debug('start preparing cursormiddle')
 		self.cursormiddle, self.continuous = prepare_cursormiddle(settings.scale * settings.settings["Cursor size"], settings, default)
-		logging.debug('start preparing cursortrail')
+		logger.debug('start preparing cursortrail')
 		self.cursor_trail = prepare_cursortrail(settings.scale * settings.settings["Cursor size"], self.continuous, settings)
 
-		logging.debug('start preparing scorenetry')
+		logger.debug('start preparing scoreentry')
 		self.scoreentry = prepare_scoreentry(settings.scale, skin.colours["InputOverlayText"], settings)
 		self.inputoverlayBG = prepare_inputoverlaybg(settings.scale, settings)
 		self.key = prepare_inputoverlay(settings.scale, [255, 220, 20], 2, settings)
 		self.mouse = prepare_inputoverlay(settings.scale, [220, 0, 220], 1, settings)
 
-		logging.debug('start preparing scorenumber')
+		logger.debug('start preparing scorenumber')
 		self.scorenumbers = ScoreNumbers(settings.scale, settings)
 		self.hitcirclenumber = prepare_hitcirclenumber(diff, settings.playfieldscale, settings)
 
-		logging.debug('start preparing accuracy')
+		logger.debug('start preparing accuracy')
 		self.accuracy = prepare_accuracy(self.scorenumbers)
 		self.combocounter = prepare_combo(self.scorenumbers, settings)
 		self.hitresult = prepare_hitresults(settings.scale, diff, settings)
@@ -125,21 +125,21 @@ class PreparedFrames:
 
 		self.fpmanager = prepare_fpmanager(settings.playfieldscale, settings)
 
-		logging.debug('start preparing circle')
+		logger.debug('start preparing circle')
 		self.circle = prepare_circle(diff, settings.playfieldscale, settings, hd)
 		self.slider = prepare_slider(diff, settings.playfieldscale, settings)
 		self.spinner = prepare_spinner(settings.playfieldscale, settings)
 
-		logging.debug('start preparing background')
+		logger.debug('start preparing background')
 		self.bg = prepare_background(os.path.join(settings.beatmap, bg[2]), settings)
 
-		logging.debug('start preparing sections')
+		logger.debug('start preparing sections')
 		self.sections = prepare_sections(settings.scale, settings)
 		self.scorebarbg = prepare_scorebarbg(settings.scale, self.bg, settings)
 		self.scorebar = prepare_scorebar(settings.scale, settings)
 		self.arrowwarning = prepare_arrowwarning(settings.scale, settings)
 
-		logging.debug('start preparing scoreboard')
+		logger.debug('start preparing scoreboard')
 		self.scoreboardscore = prepare_scoreboardscore(settings.scale, settings)
 		self.scoreboard = prepare_scoreboard(settings.scale, settings)
 		self.scoreboardeffect = prepare_scoreboardeffect(settings.scale)
@@ -156,13 +156,13 @@ class PreparedFrames:
 			self.menuback = prepare_menuback(settings.scale, settings)
 			self.rankingreplay = prepare_rankingreplay(settings.scale, settings)
 			self.rankinggraph = prepare_rankinggraph(settings.scale, settings)
-			logging.debug("start preparing ur ranking")
+			logger.debug("start preparing ur ranking")
 			self.rankingur = prepare_rankingur(settings, ur)
 			self.rankinggraph.extend(self.rankingur)
 
 		self.flashlight = prepare_flashlight(settings, fl)
 		self.urarrow = prepare_urarrow(settings)
-		logging.debug('start preparing done')
+		logger.debug('start preparing done')
 
 
 class FrameObjects:

--- a/osr2mp4/VideoProcess/CreateFrames.py
+++ b/osr2mp4/VideoProcess/CreateFrames.py
@@ -5,7 +5,7 @@ import cv2
 
 from multiprocessing import Process, Pipe
 from multiprocessing.sharedctypes import RawArray
-import logging
+from osr2mp4 import logger
 from osr2mp4.VideoProcess.Draw import draw_frame, Drawer
 from osr2mp4.VideoProcess.FrameWriter import write_frame, getwriter
 import os
@@ -16,7 +16,7 @@ def update_progress(framecount, deltatime, videotime):
 
 
 def create_frame(settings, beatmap, replay_info, resultinfo, videotime, showranking):
-	logging.debug('entering preparedframes')
+	logger.debug('entering preparedframes')
 
 	if settings.process >= 1:
 		shared_array = []
@@ -57,12 +57,12 @@ def create_frame(settings, beatmap, replay_info, resultinfo, videotime, showrank
 			writers.append(writer)
 
 			my_file.write("file '{}'\n".format(f))
-			logging.debug("Starting process")
+			logger.debug("Starting process")
 
 			drawer.start()
-			logging.debug("Start drawer {}".format(i))
+			logger.debug("Start drawer {}".format(i))
 			writer.start()
-			logging.debug("Start writer {}".format(i))
+			logger.debug("Start writer {}".format(i))
 
 			start += osr_interval
 		my_file.close()
@@ -74,7 +74,7 @@ def create_frame(settings, beatmap, replay_info, resultinfo, videotime, showrank
 		from osr2mp4.CheckSystem.mathhelper import getunstablerate
 		import numpy as np
 
-		logging.debug("process start")
+		logger.debug("process start")
 
 		ur = getunstablerate(resultinfo)
 		frames = PreparedFrames(settings, beatmap.diff, replay_info.mod_combination, ur=ur, bg=beatmap.bg, loadranking=showranking)
@@ -89,7 +89,7 @@ def create_frame(settings, beatmap, replay_info, resultinfo, videotime, showrank
 		writer = getwriter(f, settings, buf)
 		buf = buf.reshape((settings.height, settings.width, 3))
 
-		logging.debug("setup done")
+		logger.debug("setup done")
 		framecount = 0
 		startwritetime = time.time()
 		while drawer.frame_info.osr_index < videotime[1]:
@@ -121,6 +121,6 @@ def create_frame(settings, beatmap, replay_info, resultinfo, videotime, showrank
 				else:
 					writer.write()
 		writer.release()
-		logging.debug("\nprocess done")
+		logger.debug("\nprocess done")
 
 		return None, None, None, None

--- a/osr2mp4/VideoProcess/DiskUtils.py
+++ b/osr2mp4/VideoProcess/DiskUtils.py
@@ -2,12 +2,15 @@ import os
 import subprocess
 import shutil
 
+from osr2mp4 import log_stream
+
 
 def concat_videos(settings):
 	_, file_extension = os.path.splitext(settings.output)
 	f = os.path.join(settings.temp, "outputf" + file_extension)
 	listvideopath = os.path.abspath(os.path.join(settings.temp, "listvideo.txt")).replace("\\", "/")
-	subprocess.check_call([settings.ffmpeg, '-safe', '0', '-f', 'concat', '-i', listvideopath, '-c', 'copy', f, '-y'])
+	stream = log_stream()
+	subprocess.check_call([settings.ffmpeg, '-safe', '0', '-f', 'concat', '-i', listvideopath, '-c', 'copy', f, '-y'], stdout=stream, stderr=stream)
 
 
 def rename_video(settings):
@@ -27,7 +30,8 @@ def cleanup(settings):
 def mix_video_audio(settings):
 	_, file_extension = os.path.splitext(settings.output)
 	f = os.path.join(settings.temp, "outputf" + file_extension)
-	subprocess.check_call([settings.ffmpeg, '-i', f, '-i', settings.temp + 'audio.mp3', '-c:v', 'copy', '-c:a', settings.audiocodec, '-ab', str(settings.settings["Audio bitrate"]) + "k", settings.output, '-y'])
+	stream = log_stream()
+	subprocess.check_call([settings.ffmpeg, '-i', f, '-i', settings.temp + 'audio.mp3', '-c:v', 'copy', '-c:a', settings.audiocodec, '-ab', str(settings.settings["Audio bitrate"]) + "k", settings.output, '-y'], stdout=stream, stderr=stream)
 
 
 def convert_tomp4(settings, output="output.mp4"):

--- a/osr2mp4/VideoProcess/Draw.py
+++ b/osr2mp4/VideoProcess/Draw.py
@@ -225,7 +225,7 @@ def draw(shared, conn, beatmap, replay_info, resultinfo, videotime, settings, sh
 			i = conn.recv()
 
 	conn.send(10)
-	logger.debug("End draw", time.time() - asdfasdf)
+	logger.debug("End draw: %f", time.time() - asdfasdf)
 	logger.debug("\nprocess done {}, {}".format(videotime, drawer))
 	logger.debug("Drawing time: {}".format(timer))
 	logger.debug("Total time: {}".format(time.time() - asdfasdf))

--- a/osr2mp4/VideoProcess/Draw.py
+++ b/osr2mp4/VideoProcess/Draw.py
@@ -7,6 +7,7 @@ import traceback
 from PIL import Image
 from osr2mp4.osrparse.replay import Replay
 
+from osr2mp4 import logger
 from osr2mp4.CheckSystem.Health import HealthProcessor
 from osr2mp4.ImageProcess import imageproc
 from osr2mp4.Utils.skip import skip
@@ -184,13 +185,13 @@ def draw_frame(shared, conn, beatmap, replay_info, resultinfo, videotime, settin
 		tb = traceback.format_exc()
 		with open("error.txt", "w") as fwrite:  # temporary fix
 			fwrite.write(repr(e))
-		logging.error("{} from {}\n{}\n\n\n".format(tb, videotime, repr(e)))
+		logger.error("{} from {}\n{}\n\n\n".format(tb, videotime, repr(e)))
 		raise
 
 
 def excepthook(exc_type, exc_value, exc_tb):
 	tb = traceback.format_exc()
-	logging.exception(tb)
+	logger.exception(tb)
 	print(tb)
 
 
@@ -198,17 +199,17 @@ def draw(shared, conn, beatmap, replay_info, resultinfo, videotime, settings, sh
 	sys.excepthook = excepthook
 	asdfasdf = time.time()
 
-	logging.log(1, "CALL {}, {}".format(videotime, showranking))
-	logging.log(logging.DEBUG, "process start")
+	logger.log(1, "CALL {}, {}".format(videotime, showranking))
+	logger.debug("process start")
 
 	ur = getunstablerate(resultinfo)
 	frames = PreparedFrames(settings, beatmap.diff, replay_info.mod_combination, ur=ur, bg=beatmap.bg, loadranking=showranking)
 
 	drawer = Drawer(shared, beatmap, frames, replay_info, resultinfo, videotime, settings)
 
-	logging.log(1, "PROCESS {}, {}".format(videotime, drawer))
+	logger.log(1, "PROCESS {}, {}".format(videotime, drawer))
 
-	logging.log(logging.DEBUG, "setup done")
+	logger.debug("setup done")
 	print("Starting draw")
 	timer = 0
 	timer2 = 0
@@ -232,8 +233,8 @@ def draw(shared, conn, beatmap, replay_info, resultinfo, videotime, settings, sh
 
 	conn.send(10)
 	print("End draw", time.time() - asdfasdf)
-	logging.debug("\nprocess done {}, {}".format(videotime, drawer))
-	logging.debug("Drawing time: {}".format(timer))
-	logging.debug("Total time: {}".format(time.time() - asdfasdf))
-	logging.debug("Waiting time: {}".format(timer2))
-	logging.debug("Changing value time: {}".format(timer3))
+	logger.debug("\nprocess done {}, {}".format(videotime, drawer))
+	logger.debug("Drawing time: {}".format(timer))
+	logger.debug("Total time: {}".format(time.time() - asdfasdf))
+	logger.debug("Waiting time: {}".format(timer2))
+	logger.debug("Changing value time: {}".format(timer3))

--- a/osr2mp4/VideoProcess/Draw.py
+++ b/osr2mp4/VideoProcess/Draw.py
@@ -189,14 +189,7 @@ def draw_frame(shared, conn, beatmap, replay_info, resultinfo, videotime, settin
 		raise
 
 
-def excepthook(exc_type, exc_value, exc_tb):
-	tb = traceback.format_exc()
-	logger.exception(tb)
-	print(tb)
-
-
 def draw(shared, conn, beatmap, replay_info, resultinfo, videotime, settings, showranking):
-	sys.excepthook = excepthook
 	asdfasdf = time.time()
 
 	logger.log(1, "CALL {}, {}".format(videotime, showranking))
@@ -210,7 +203,7 @@ def draw(shared, conn, beatmap, replay_info, resultinfo, videotime, settings, sh
 	logger.log(1, "PROCESS {}, {}".format(videotime, drawer))
 
 	logger.debug("setup done")
-	print("Starting draw")
+	logger.debug("Starting draw")
 	timer = 0
 	timer2 = 0
 	timer3 = 0
@@ -232,7 +225,7 @@ def draw(shared, conn, beatmap, replay_info, resultinfo, videotime, settings, sh
 			i = conn.recv()
 
 	conn.send(10)
-	print("End draw", time.time() - asdfasdf)
+	logger.debug("End draw", time.time() - asdfasdf)
 	logger.debug("\nprocess done {}, {}".format(videotime, drawer))
 	logger.debug("Drawing time: {}".format(timer))
 	logger.debug("Total time: {}".format(time.time() - asdfasdf))

--- a/osr2mp4/VideoProcess/FFmpegWriter/testcodec.py
+++ b/osr2mp4/VideoProcess/FFmpegWriter/testcodec.py
@@ -1,3 +1,4 @@
+from osr2mp4 import logger
 from osr2mp4cv import getaudiocodec
 
 a = getaudiocodec()
@@ -7,4 +8,4 @@ for x in a:
 	codec[x.decode("utf-8")] = a[x].decode("utf-8")
 
 for x in codec:
-	print(f"{x}: {codec[x]}")
+	logger.debug(f"{x}: {codec[x]}")

--- a/osr2mp4/VideoProcess/FrameWriter.py
+++ b/osr2mp4/VideoProcess/FrameWriter.py
@@ -51,7 +51,7 @@ def write(shared, conn, filename, settings, iii):
 	asdfasdf = time.time()
 
 	logger.debug("{}\n".format(filename))
-	print("Start write")
+	logger.debug("Start write")
 
 	if settings.codec.lower() in videoextensions:
 		raise FourccIsNotExtension()
@@ -109,10 +109,10 @@ def write(shared, conn, filename, settings, iii):
 		filewriter.write("done")
 		filewriter.close()
 
-	print("Release write")
+	logger.debug("Release write")
 	writer.release()
 
-	print("End write")
+	logger.debug("End write")
 
 	logger.debug("\nWriting done {}".format(filename))
 	logger.debug("Writing time: {}".format(timer))

--- a/osr2mp4/VideoProcess/FrameWriter.py
+++ b/osr2mp4/VideoProcess/FrameWriter.py
@@ -1,9 +1,9 @@
-import logging
 import os
 import time
 import traceback
 import numpy as np
 import cv2
+from osr2mp4 import logger
 from osr2mp4.global_var import videoextensions
 from osr2mp4.Exceptions import CannotCreateVideo, FourccIsNotExtension, WrongFourcc, LibAvNotFound
 
@@ -15,7 +15,7 @@ def write_frame(shared, conn, filename, settings, iii):
 		tb = traceback.format_exc()
 		with open("error.txt", "w") as fwrite:  # temporary fix
 			fwrite.write(repr(e))
-		logging.error("{} from {}\n{}\n\n\n".format(tb, filename, repr(e)))
+		logger.error("{} from {}\n{}\n\n\n".format(tb, filename, repr(e)))
 		raise
 
 
@@ -50,7 +50,7 @@ def getwriter(filename, settings, buf):
 def write(shared, conn, filename, settings, iii):
 	asdfasdf = time.time()
 
-	logging.log(logging.DEBUG, "{}\n".format(filename))
+	logger.debug("{}\n".format(filename))
 	print("Start write")
 
 	if settings.codec.lower() in videoextensions:
@@ -69,7 +69,7 @@ def write(shared, conn, filename, settings, iii):
 	timer3 = 0
 	a = 0
 	framecount = 1
-	logging.log(logging.DEBUG, "start writing: %f", time.time() - asdfasdf)
+	logger.debug("start writing: %f", time.time() - asdfasdf)
 
 	startwringtime = time.time()
 
@@ -101,7 +101,7 @@ def write(shared, conn, filename, settings, iii):
 			if iii and framecount % 200:
 				deltatime = max(1, timer)
 				filewriter.seek(0)
-				# logging.log(1, "Writing progress {}, {}, {}, {}".format(framecount, deltatime, filename, startwringtime))
+				# logger.log(1, "Writing progress {}, {}, {}, {}".format(framecount, deltatime, filename, startwringtime))
 				filewriter.write("{}\n{}\n{}\n{}".format(framecount, deltatime, filename, startwringtime))
 				filewriter.truncate()
 
@@ -114,8 +114,8 @@ def write(shared, conn, filename, settings, iii):
 
 	print("End write")
 
-	logging.debug("\nWriting done {}".format(filename))
-	logging.debug("Writing time: {}".format(timer))
-	logging.debug("Total time: {}".format(time.time() - asdfasdf))
-	logging.debug("Waiting time: {}".format(timer2))
-	logging.debug("Changing value time: {}".format(timer3))
+	logger.debug("\nWriting done {}".format(filename))
+	logger.debug("Writing time: {}".format(timer))
+	logger.debug("Total time: {}".format(time.time() - asdfasdf))
+	logger.debug("Waiting time: {}".format(timer2))
+	logger.debug("Changing value time: {}".format(timer3))

--- a/osr2mp4/VideoProcess/calc.py
+++ b/osr2mp4/VideoProcess/calc.py
@@ -1,3 +1,4 @@
+from osr2mp4 import logger
 from osr2mp4.EEnum.EReplay import Replays
 
 
@@ -71,7 +72,7 @@ def add_hitobjects(beatmap, component, frame_info, time_preempt, settings):
 	# check if it's time to draw circles
 	if frame_info.cur_time + time_preempt >= osu_d["time"] and frame_info.index_hitobj + 1 < len(beatmap.hitobjects):
 
-		# logging.log(1, "Adding osu object {}\n{}".format(osu_d, frame_info))
+		# logger.log(1, "Adding osu object {}\n{}".format(osu_d, frame_info))
 
 		if "spinner" in osu_d["type"]:
 

--- a/osr2mp4/__init__.py
+++ b/osr2mp4/__init__.py
@@ -1,6 +1,17 @@
 #import os, sys; sys.path.append(os.path.dirname(os.path.realpath(__file__)))
 
 import logging
+import os
+import sys
 
 logger = logging.getLogger(__name__)
 logger.propagate = False
+
+
+def log_stream():
+	if not logger.handlers:
+		return sys.stdout
+	handler = logger.handlers[0]
+	if hasattr(handler, "stream"):
+		return handler.stream
+	return open(os.devnull, "w")

--- a/osr2mp4/__init__.py
+++ b/osr2mp4/__init__.py
@@ -1,1 +1,5 @@
 #import os, sys; sys.path.append(os.path.dirname(os.path.realpath(__file__)))
+
+import logging
+
+logger = logging.getLogger(__name__)

--- a/osr2mp4/__init__.py
+++ b/osr2mp4/__init__.py
@@ -3,3 +3,4 @@
 import logging
 
 logger = logging.getLogger(__name__)
+logger.propagate = False

--- a/osr2mp4/osr2mp4.py
+++ b/osr2mp4/osr2mp4.py
@@ -62,8 +62,10 @@ class Osr2mp4:
 		logger.setLevel(TRACE)
 		if logtofile:
 			handler = logging.FileHandler(logpath)
+		elif enablelog:
+			handler = logging.StreamHandler(sys.stdout)
 		else:
-			handler = logging.StreamHandler(sys.stdout if enablelog else os.devnull)
+			handler = logging.NullHandler()
 		logger.handlers.clear()
 		logger.addHandler(handler)
 

--- a/osr2mp4/osr2mp4.py
+++ b/osr2mp4/osr2mp4.py
@@ -67,6 +67,7 @@ class Osr2mp4:
 		else:
 			handler = logging.NullHandler()
 		logger.handlers.clear()
+		handler.setFormatter(fmt)
 		logger.addHandler(handler)
 
 		self.settings.enablelog = enablelog


### PR DESCRIPTION
Closes #65 

The output of ffmpeg commands are still printed to stdout/stderr even when using a file or null logger, so it's not entirely silent, but it's a big improvement IMO. Maybe I'll work on putting the ffmpeg output into the log stream later in a separate branch.

edit: it actually wasn't very hard

I also removed one place where `sys.excepthook` is set, since it's already set in the `Osr2mp4` constructor.
