### PR TITLE
AudioNotFound Fix

### DIFF
--- a/osr2mp4/AudioProcess/CreateAudio.py
+++ b/osr2mp4/AudioProcess/CreateAudio.py
@@ -169,6 +169,12 @@ def processaudio(my_info, beatmap, offset, endtime, mods, settings):
 		logger.error("{} from audio\n\n\n".format(error))
 		raise
 
+def get_actual_audio_filename(audio_filename, beatmap_path):
+	files_in_dir = os.listdir(beatmap_path)
+	for ind, file in enumerate(files_in_dir):
+		if(audio_filename.lower() == file.lower()):
+			return file
+	raise FileNotFoundError
 
 def audioprc(my_info, beatmap, offset, endtime, mods, settings):
 	nc = Mod.Nightcore in mods
@@ -182,6 +188,7 @@ def audioprc(my_info, beatmap, offset, endtime, mods, settings):
 	ccc = time.time()
 
 	try:
+		audio_name = get_actual_audio_filename(audio_name, beatmap_path)
 		song = Audio2p(*read(os.path.join(beatmap_path, audio_name), settings, volume=settings.settings["Song volume"]/100, speed=settings.timeframe/1000, changepitch=nc))
 	except FileNotFoundError:
 		raise AudioNotFound()

--- a/osr2mp4/AudioProcess/CreateAudio.py
+++ b/osr2mp4/AudioProcess/CreateAudio.py
@@ -171,7 +171,7 @@ def processaudio(my_info, beatmap, offset, endtime, mods, settings):
 
 def get_actual_audio_filename(audio_filename, beatmap_path):
 	files_in_dir = os.listdir(beatmap_path)
-	for ind, file in enumerate(files_in_dir):
+	for file in files_in_dir:
 		if(audio_filename.lower() == file.lower()):
 			return file
 	raise FileNotFoundError


### PR DESCRIPTION
For some maps such as https://osu.ppy.sh/beatmapsets/532522#osu/1128411 and https://osu.ppy.sh/beatmapsets/499478#osu/1161445 the audio mp3 extension in the osu file is incorrectly uppercased as .MP3 rather than .mp3.  These are the only two cases of AudioNotFound errors that ive found so far.

This fix lists all the files in the beatmap directory and matches the audio file name to each file with all lowercase matching.  It then returns the original file name that is inside the beatmap directory.