### PR TITLE
Add default "Center Text" pp config

### DIFF
--- a/osr2mp4/global_var.py
+++ b/osr2mp4/global_var.py
@@ -44,6 +44,7 @@ defaultppconfig = {
 	"Alpha": 1,
 	"Font": "arial.ttf",
 	"Background": os.path.join(os.path.dirname(__file__), "res/pptemplate.png"),
+	"Center Text": False,
 	"Hitresult x": 50,
 	"Hitresult y": 150,
 	"Hitresult Size": 16,
@@ -55,7 +56,7 @@ defaultppconfig = {
 	"Hitresult Alpha": 1,
 	"Hitresult Font": "arial.ttf",
 	"Hitresult Background": os.path.join(os.path.dirname(__file__), "res/hitresulttemplate.png"),
-	"Hitresult Gap": 3
+	"Hitresult Gap": 3,
 }
 
 defaultstrainconfig = {


### PR DESCRIPTION
Really this line should be `self.countersettings.get("Center Text")` but :shrug:

https://github.com/uyitroa/osr2mp4-core/blob/146e7c37a973038edf5af2da4e9cc92f0d633665/osr2mp4/ImageProcess/Objects/Scores/ACounter.py#L53